### PR TITLE
Update image-comparison-slider.js

### DIFF
--- a/image-comparison-slider.js
+++ b/image-comparison-slider.js
@@ -33,8 +33,8 @@
 
         elsH[i].addEventListener("mousemove", function(e) {
             if (mouseDownX) {
-                this.style.left = parseInt(this.style.left) + (event.clientX - X) + "px";
-                X = event.clientX;
+                this.style.left = parseInt(this.style.left) + (e.clientX - X) + "px";
+                X = e.clientX;
                 this.nextElementSibling.style.clip = "rect(0px, " + (this.getBoundingClientRect().width / 2 + parseInt(this.style.left)) + "px, " + this.getBoundingClientRect().height + "px, 0px)";
             }
         });


### PR DESCRIPTION
Fix "mousemove" handler

See [Stackoverflow](https://stackoverflow.com/questions/52388105/image-comparison-slider-written-in-javascript-not-working-in-firefox)